### PR TITLE
We only need `PMKPromise`, not the whole Kit

### DIFF
--- a/MBTNetworking.podspec
+++ b/MBTNetworking.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
   
   s.dependency 'AFNetworking', '~> 2.5'
   s.dependency 'Mantle', '~> 1.5'
-  s.dependency 'PromiseKit', '~> 1.2'
+  s.dependency 'PromiseKit/Promise', '~> 1.2'
 end


### PR DESCRIPTION
Nice framework! I noticed you pull in the whole of PromiseKit, but I tried linting the pod using just the "Promise" subspec and it worked.

If you ever need eg. when you can add the extra subspecs.

Users will need to depend on the whole of PromiseKit if they want other category features (e.g.. CoreLocation promises). But this seems like the right thing to do.
